### PR TITLE
Ensure 'manage_database' only manages the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,7 @@ Default: `true`
 
 #### `manage_database`
 
-Installs a local MySQL server, the MySQL client bindings for
-python, and the MySQL development libraries which are required by the
-python bindings.
+Installs a local MySQL server.
 
 Default: `true`
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -40,16 +40,18 @@ class patchwork::install {
 
   if ($patchwork::manage_database) {
     class { '::mysql::server': }
-    # Manually install mariadb-devel until mysql module updates with the code
-    # that fixes this.
-    #class { '::mysql::bindings::daemon_dev': }
-    package { 'mysql-daemon_dev':
-      ensure => 'present',
-      name   => 'mariadb-devel',
-    }
-    class { '::mysql::bindings':
-      python_enable => true,
-    }
+  }
+
+  # Manually install mariadb-devel until mysql module updates with the code
+  # that fixes this.
+  #  include '::mysql::bindings::daemon_dev'
+  package { 'mysql-daemon_dev':
+    ensure => 'present',
+    name   => 'mariadb-devel',
+  }
+  # Install mysql python bindings
+  class { '::mysql::bindings':
+    python_enable => true,
   }
 
   # If 'latest' version is given the repo will track master and keep up

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -79,6 +79,8 @@ describe 'patchwork', :type => 'class' do
         :manage_database => false,
       }}
       it { should_not contain_class('mysql::server') }
+      it { should contain_package('mysql-daemon_dev') }
+      it { should contain_class('mysql::bindings') }
     end
     context 'with unmanaged python' do
       let(:params) {{


### PR DESCRIPTION
The 'manage_database' flag was managing _too_ much.

Installing patchwork without a local database server should still allow
it to connect to mysql and install the required python client bindings.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>