### PR TITLE
Use 'include' for classes declared by manage flags

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,7 +25,7 @@
 class patchwork::install {
 
   if ($patchwork::manage_git) {
-    class { '::git': }
+    include ::git
   }
 
   if ($patchwork::manage_python) {
@@ -39,7 +39,7 @@ class patchwork::install {
   }
 
   if ($patchwork::manage_database) {
-    class { '::mysql::server': }
+    include ::mysql::server
   }
 
   # Manually install mariadb-devel until mysql module updates with the code


### PR DESCRIPTION
Allows for managing configuration for 'git' and 'mysql::server' through
an ENC or hiera. Python is still declared because it need to explicitly
manage virtualenv, pip, and python-dev.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>