### PR TITLE
Disable reporting changes to settings.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,10 @@ Default: `10`
 ### patchwork::config
 
 Manages the Django settings.py file. Most parameter are passed directly
-through and interpreted as Python.
+through and interpreted as Python. Because settings.py may contain
+sensitive information,
+[show_diff](https://docs.puppetlabs.com/puppet/latest/reference/type.html#file-attribute-show_diff)
+is disabled for the file.
 
 #### `secret_key`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -100,11 +100,12 @@ class patchwork::config (
   validate_array($allowed_hosts)
 
   file { "${patchwork::install_dir}/patchwork/settings/production.py":
-    ensure  => file,
-    mode    => '0644',
-    owner   => $patchwork::user,
-    group   => $patchwork::group,
-    content => template("${module_name}/settings.py.erb"),
+    ensure    => file,
+    mode      => '0644',
+    owner     => $patchwork::user,
+    group     => $patchwork::group,
+    content   => template("${module_name}/settings.py.erb"),
+    show_diff => false,
   }
 
   file { "${patchwork::install_dir}/patchwork.wsgi":

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -14,7 +14,7 @@ describe 'patchwork::config', :type => 'class' do
            .with_content(/ALLOWED_HOSTS = \(\s+\)/)
     }
   end
-  context 'with defaults for all parameters' do
+  context 'with changes to all parameters' do
     let(:params) {{
       :time_zone => 'US/PST',
       :from_email => '<foo@example.com>',
@@ -31,6 +31,7 @@ describe 'patchwork::config', :type => 'class' do
            .with(
                'owner' => 'patchwork',
                'group' => 'patchwork',
+               'show_diff' => 'false',
             )
            .with_content(/LANGUAGE_CODE = 'fi-SE'/)
            .with_content(/TIME_ZONE = 'US\/PST'/)


### PR DESCRIPTION
Settings may contain sensivive information such as the SECRET_KEY and
Database password. By setting show_diff to false, we keep Puppet from
sending diffs of the file and potentially revealing secrets over
unsecure channels.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>