### PR TITLE
Allow Overriding of uwsgi Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,12 @@ database server.
 
 Default: `'mysql-patchwork'`
 
-#### `uwsgi_options`
+#### `uwsgi_overrides`
 
-Options hash passed to the patchwork uwsgi application.
+Items in the hash will replace the defaults listed in `uwsgi_options` of
+the params class.
 
-Default:
+`patchwork::params::uwsgi_options` is defined as:
 ```puppet
 {
   virtualenv  => '/opt/patchwork/venv',
@@ -178,6 +179,8 @@ Default:
   threads     => 2,
 }
 ```
+
+Default: `{}`
 
 #### `collect_exported`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,12 @@
 #   
 #   Default: true
 #
+# [*uwsgi_overrides*]
+#   Items in the hash will replace the defaults listed in
+#   `uwsgi_options` of the params class.
+#
+#   Default: {}
+#
 # === Authors
 #
 # Trevor Bramwell <tbramwell@linuxfoundation.org>
@@ -82,7 +88,7 @@ class patchwork (
   $database_user     = $patchwork::params::database_user,
   $database_pass     = $patchwork::params::database_pass,
   $database_tag      = $patchwork::params::database_tag,
-  $uwsgi_options     = $patchwork::params::uwsgi_options,
+  $uwsgi_overrides   = {},
   $collect_exported  = $patchwork::params::collect_exported,
   $cron_minutes      = $patchwork::params::cron_minutes,
 ) inherits patchwork::params {
@@ -101,9 +107,11 @@ class patchwork (
   validate_string($database_user)
   validate_string($database_pass)
   validate_string($database_tag)
-  validate_hash($uwsgi_options)
+  validate_hash($uwsgi_overrides)
   validate_bool($collect_exported)
   validate_integer($cron_minutes, 59, 0)
+
+  $uwsgi_config = merge($patchwork::params::uwsgi_options, $uwsgi_overrides)
 
   anchor { 'patchwork:begin': }
   anchor { 'patchwork:end': }

--- a/manifests/uwsgi.pp
+++ b/manifests/uwsgi.pp
@@ -37,8 +37,8 @@ class patchwork::uwsgi {
 
   include ::uwsgi
 
-  if (has_key($patchwork::uwsgi_options, 'logto')) {
-    $log_dir = dirname($patchwork::uwsgi_options['logto'])
+  if (has_key($patchwork::uwsgi_config, 'logto')) {
+    $log_dir = dirname($patchwork::uwsgi_config['logto'])
     validate_absolute_path($log_dir)
 
     file { $log_dir:
@@ -52,7 +52,7 @@ class patchwork::uwsgi {
     ensure              => 'present',
     uid                 => $patchwork::user,
     gid                 => $patchwork::group,
-    application_options => $patchwork::uwsgi_options,
+    application_options => $patchwork::uwsgi_config,
   }
 
 }

--- a/spec/classes/uwsgi_spec.rb
+++ b/spec/classes/uwsgi_spec.rb
@@ -28,5 +28,29 @@ describe 'patchwork', :type => 'class' do
         })
       }
     end
+    context 'with overrides for options' do
+      let(:params) {{
+        :uwsgi_overrides => {
+            'http-socket' => ':2222',
+            'master' => false,
+            'threads' => 8,
+        }
+      }}
+      it { should contain_uwsgi__app('patchwork')
+           .with({
+             'application_options' => {
+               'virtualenv'  => '/opt/patchwork/venv',
+               'chdir'       => '/opt/patchwork',
+               'logto'       => '/var/log/patchwork/uwsgi.log',
+               'master'      => false,
+               'http-socket' => ':2222',
+               'static-map'  => '/static=/opt/patchwork/htdocs',
+               'wsgi-file'   => 'patchwork.wsgi',
+               'processes'   => 4,
+               'threads'     => 8,
+             }
+           })
+      }
+    end
   end
 end


### PR DESCRIPTION
`uwsgi_overrides` is used to override the defaults listed in
`params::uwsgi_options`. This removes the `uwsgi_options` parameter so
as to not create confusion between which should be used. If both were
available it would not make sense to override a hash already passed in
(uwsgi_options), as a user could just edit that hash.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>