### PR TITLE
Create databases using ipaddress for host

### DIFF
--- a/manifests/database/mysql.pp
+++ b/manifests/database/mysql.pp
@@ -30,7 +30,7 @@ class patchwork::database::mysql {
       user     => $patchwork::database_user,
       password => $patchwork::database_pass,
       dbname   => $patchwork::database_name,
-      host     => $patchwork::database_host,
+      host     => $::ipaddress,
       tag      => $patchwork::database_tag,
     }
   } else {
@@ -38,7 +38,7 @@ class patchwork::database::mysql {
       ensure   => 'present',
       user     => $patchwork::database_user,
       password => $patchwork::database_pass,
-      host     => $patchwork::database_host,
+      host     => $::ipaddress,
     }
   }
 }

--- a/spec/classes/database/mysql_spec.rb
+++ b/spec/classes/database/mysql_spec.rb
@@ -10,7 +10,7 @@ describe 'patchwork::database::mysql', :type => 'class' do
              'dbname'   => 'patchwork',
              'user'     => 'patchwork',
              'password' => 'patchwork',
-             'host'     => 'localhost',
+             'host'     => '172.16.32.42',
            }) }
   end
   context 'with exported resourced enabled' do
@@ -22,7 +22,7 @@ describe 'patchwork::database::mysql', :type => 'class' do
              'dbname'   => 'patchwork',
              'user'     => 'patchwork',
              'password' => 'patchwork',
-             'host'     => 'localhost',
+             'host'     => '172.16.32.42',
            }) }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ RSpec.configure do |c|
   c.default_facts = {
     :osfamily                  => 'RedHat',
     :operatingsystem           => 'CentOS',
-    :ipaddress                 => '192.168.0.2',
+    :ipaddress                 => '172.16.32.42',
     :operatingsystemmajrelease => '7',
     :fqdn                      => 'patchwork.example.com',
     :hostname                  => 'patchwork',


### PR DESCRIPTION
The 'database_host' option is really for the client. Using it in
database creation is confusing because the `mysql::database` resource
host parameter specifies the host the database should be created on.
This is not always the same as the host the client should connect to.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>