### PR TITLE
Update version dependency on Python module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,7 +6,7 @@ fixtures:
     epel: 'stahnma-epel'
     python:
       repo: 'stankevich-python'
-      ref: '1.9.4'
+      ref: '1.11.0'
     mysql: 'puppetlabs-mysql'
     uwsgi:
       repo: 'engage-uwsgi'

--- a/metadata.json
+++ b/metadata.json
@@ -32,7 +32,7 @@
     },
     {
       "name":"stankevich-python",
-      "version_requirement":">=1.0.0 <=1.9.7"
+      "version_requirement":">=1.11.0 <2.0.0"
     },
     {
       "name":"engage-uwsgi",


### PR DESCRIPTION
Quite a few issues have been fixed since the 1.9.4 release of
stankevich-python. As Python is the most important part of Patchwork
running, it's important the module stays up to date with patches.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>