### PR TITLE
Tweak selinux policy to search uwsgi logdir

### DIFF
--- a/files/mypatchwork.te
+++ b/files/mypatchwork.te
@@ -1,4 +1,4 @@
-module mypatchwork 1.0.2;
+module mypatchwork 1.0.3;
 
 require {
         type httpd_t;
@@ -7,9 +7,11 @@ require {
         type ldconfig_exec_t;
         type postfix_pipe_t;
         class file { getattr execute_no_trans read open execute append };
+        class dir { search };
 }
 
 #============= postfix_pipe_t ==============
 allow postfix_pipe_t ldconfig_exec_t:file { read execute open execute_no_trans };
+allow postfix_pipe_t httpd_log_t:dir search;
 allow postfix_pipe_t httpd_log_t:file { getattr open append };
 allow httpd_t sysctl_net_t:file { read open };


### PR DESCRIPTION
Since uwsgi is now running as httpd_t, the parsemail script needs to be
able to access the httpd_log_t directory in addition to writing to
httpd_log_t files.

Signed-off-by: Konstantin Ryabitsev <konstantin@linuxfoundation.org>