### PR TITLE
Add logrotation for uwsgi.log

### DIFF
--- a/files/logrotate.d/patchwork
+++ b/files/logrotate.d/patchwork
@@ -9,3 +9,13 @@
     missingok
     notifempty
 }
+
+/var/log/patchwork/uwsgi.log {
+    weekly
+    rotate 4
+    copytruncate
+    compress
+    delaycompress
+    missingok
+    notifempty
+}


### PR DESCRIPTION
Not sure if the uwsgi.log location is defined by a parameter, which would make this a template instead of a file.